### PR TITLE
fix typo

### DIFF
--- a/_posts/2015-12-21-python-dict-functions.md
+++ b/_posts/2015-12-21-python-dict-functions.md
@@ -66,7 +66,7 @@ operations = {
     'subtract': subtract
 }
 
-# add variables x & y
+# add variables x, y, z, p, q, r
 print operations['add'](x, y, z, p, q, r)
 # 155
 


### PR DESCRIPTION
I the post about using functions in dictionaries the function was to built to add 6 variables, but the comment said only x and y.